### PR TITLE
use dedicated notify token 

### DIFF
--- a/Action/NotifyAction.php
+++ b/Action/NotifyAction.php
@@ -31,6 +31,6 @@ class NotifyAction implements ActionInterface, GatewayAwareInterface
 
     public function supports($request): bool
     {
-        return $request instanceof Notify;
+        return $request instanceof Notify && $request->getModel() instanceof \ArrayAccess;
     }
 }

--- a/Action/NotifyAction.php
+++ b/Action/NotifyAction.php
@@ -31,6 +31,8 @@ class NotifyAction implements ActionInterface, GatewayAwareInterface
 
     public function supports($request): bool
     {
-        return $request instanceof Notify && $request->getModel() instanceof \ArrayAccess;
+        return
+            $request instanceof Notify &&
+            $request->getModel() instanceof \ArrayAccess;
     }
 }

--- a/Api.php
+++ b/Api.php
@@ -26,7 +26,7 @@ class Api
         return $this->getTransactionPaymentPageService()->paymentPageUrl($this->getSpaceId(), $transactionId);
     }
 
-    public function prepareTransaction(ArrayObject $details, string $returnUrl, string $tokenHash): Transaction
+    public function prepareTransaction(ArrayObject $details, string $returnUrl, string $notifyTokenHash): Transaction
     {
         $transactionExtender = [];
         if ($details->offsetExists('transaction_extender')) {
@@ -48,7 +48,7 @@ class Api
         $transaction->setAutoConfirmationEnabled(true);
         $transaction->setFailedUrl($this->getFailedUrl($returnUrl));
         $transaction->setSuccessUrl($this->getSuccessUrl($returnUrl));
-        $transaction->setMetaData(['paymentToken' => $tokenHash]);
+        $transaction->setMetaData(['paymentToken' => $notifyTokenHash]);
 
         if (array_key_exists('allowedPaymentMethodBrands', $transactionExtender)) {
             $transaction->setAllowedPaymentMethodBrands($transactionExtender['allowedPaymentMethodBrands']);

--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@ Use multiple spaces to determine test/production.
 You need to define a global webhook: `https://your-domain.com/payment/notify/unsafe/[YOUR_POSTFINANCE_FLEX_GATEWAY_NAME]`
 
 ## Changelog
---
+### 1.0.2
+- use dedicated notify token for webhooks to prevent invalidation before completing payment state submission
+### 1.0.1
+- Add `allowedPaymentMethodBrands` option
 
 ## Copyright and License
 Copyright: [DACHCOM.DIGITAL](https://www.dachcom-digital.ch)


### PR DESCRIPTION
... for webhooks to prevent invalidation before completing payment state submission