### PR TITLE
keep payment state in new

### DIFF
--- a/Action/StatusAction.php
+++ b/Action/StatusAction.php
@@ -59,9 +59,9 @@ class StatusAction implements ActionInterface, ApiAwareInterface, GatewayAwareIn
 
         if ($state === TransactionState::CREATE) {
             $request->markNew();
-        } elseif ($state === TransactionState::PENDING) {
-            $request->markPending();
         } elseif ($state === TransactionState::CONFIRMED) {
+            $request->markNew();
+        } elseif ($state === TransactionState::PENDING) {
             $request->markPending();
         } elseif ($state === TransactionState::PROCESSING) {
             $request->markPending();

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Use multiple spaces to determine test/production.
 You need to define a global webhook: `https://your-domain.com/payment/notify/unsafe/[YOUR_POSTFINANCE_FLEX_GATEWAY_NAME]`
 
 ## Changelog
+### 1.0.4
+- keep payment state at `new` even if postfinance status is `confirmed`. Reason: PF state `confirmed` only means, that the payment itself cannot be altered anymore and instantly triggers, as soon the payment transaction has been dispatched.
 ### 1.0.3
 - allow address data submission, use abstract model creation
 ### 1.0.2


### PR DESCRIPTION
Keep payment state at `new` even if post finance status is `confirmed`. Reason: PF state `confirmed` only means, that the payment itself cannot be altered anymore and instantly triggers, as soon the payment transaction has been dispatched.
