### PR TITLE
change payment state to authorized if transaction state is completed

### DIFF
--- a/Action/StatusAction.php
+++ b/Action/StatusAction.php
@@ -72,7 +72,7 @@ class StatusAction implements ActionInterface, ApiAwareInterface, GatewayAwareIn
         } elseif ($state === TransactionState::VOIDED) {
             $request->markCanceled();
         } elseif ($state === TransactionState::COMPLETED) {
-            $request->markCaptured();
+            $request->markAuthorized();
         } elseif ($state === TransactionState::FULFILL) {
             $request->markCaptured();
         } elseif ($state === TransactionState::DECLINE) {

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Use multiple spaces to determine test/production.
 You need to define a global webhook: `https://your-domain.com/payment/notify/unsafe/[YOUR_POSTFINANCE_FLEX_GATEWAY_NAME]`
 
 ## Changelog
+### 1.1.1
+- change payment state to `authorized` if transaction state is `completed`
 ### 1.1.0
 - add integration types
 - Add `allowedPaymentMethodConfigurations` option


### PR DESCRIPTION
See https://checkout.postfinance.ch/de-ch/doc/payment/transaction-process#_completed

> "Completed does not mean that the goods or services can be delivered to the customer. Depending on the payment method the funds need to be transfered before the delivery can be fulfilled (i. e. pre-payment)."

This means, we cannot apply the `captured` method on payments in that state, since the gateway is still waiting for final payments. Only `fulfill` can be declared as a captured transaction!