### PR TITLE
add TransactionCreate object

### DIFF
--- a/Action/Api/TransactionExtenderAction.php
+++ b/Action/Api/TransactionExtenderAction.php
@@ -7,6 +7,7 @@ use DachcomDigital\Payum\PostFinance\Flex\Transaction\Transaction;
 use Payum\Core\Action\ActionInterface;
 use Payum\Core\Exception\RequestNotSupportedException;
 use Payum\Core\Model\PaymentInterface;
+use PostFinanceCheckout\Sdk\Model\TransactionCreate;
 
 class TransactionExtenderAction implements ActionInterface
 {
@@ -20,7 +21,7 @@ class TransactionExtenderAction implements ActionInterface
         /** @var PaymentInterface $payment */
         $payment = $request->getFirstModel();
 
-        $transaction = new Transaction();
+        $transaction = new Transaction(new TransactionCreate());
 
         $transaction->setId($payment->getNumber());
         $transaction->setCurrency($payment->getCurrencyCode());

--- a/Action/ConvertPaymentAction.php
+++ b/Action/ConvertPaymentAction.php
@@ -49,7 +49,6 @@ class ConvertPaymentAction implements ActionInterface, ApiAwareInterface, Gatewa
         $details['transaction_extender'] = $transactionExtender->toArray();
 
         $request->setResult((array)$details);
-
     }
 
     public function supports($request): bool

--- a/README.md
+++ b/README.md
@@ -23,6 +23,22 @@ You need to define a global webhook: `https://your-domain.com/payment/notify/uns
 
 ## Changelog
 
+### 2.0.0
+- [NEW FEATURE | **BC BREAK**] `TransactionCreate` Object added: The object `DachcomDigital\Payum\PostFinance\Flex\Transaction\Transaction'` 
+now provides a `getTransactionCreateObject` method, which gives you full control over the transaction data. 
+Therefor we've removed several methods within the `Transaction` object itself.
+Use to the `TransactionCreate` object directly, to add additional data.
+  - Removed methods:
+    - `(get|set)AllowedPaymentMethodBrands`
+    - `(get|set)AllowedPaymentMethodConfigurations`
+    - `(get|set)ShippingAddress`
+    - `(get|set)BillingAddress`
+  - Signature of `transaction_extender` within the payment `details` has changed:
+    - `transactionCreate` added
+    - `allowedPaymentMethodBrands`, `allowedPaymentMethodConfigurations`, `shippingAddress`, `billingAddress` removed
+
+***
+
 ### 1.3.0
 - introduce `GetTransactionDetailsAction`
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You need to define a global webhook: `https://your-domain.com/payment/notify/uns
 ## Changelog
 
 ### 2.0.0
-- [NEW FEATURE | **BC BREAK**] `TransactionCreate` Object added: The object `DachcomDigital\Payum\PostFinance\Flex\Transaction\Transaction'` 
+- [NEW FEATURE | **BC BREAK**] `TransactionCreate` Object added: The object `DachcomDigital\Payum\PostFinance\Flex\Transaction\Transaction` 
 now provides a `getTransactionCreateObject` method, which gives you full control over the transaction data. 
 Therefor we've removed several methods within the `Transaction` object itself.
 Use to the `TransactionCreate` object directly, to add additional data.

--- a/Transaction/Transaction.php
+++ b/Transaction/Transaction.php
@@ -2,7 +2,7 @@
 
 namespace DachcomDigital\Payum\PostFinance\Flex\Transaction;
 
-use PostFinanceCheckout\Sdk\Model\AddressCreate;
+use PostFinanceCheckout\Sdk\Model\TransactionCreate;
 use PostFinanceCheckout\Sdk\ObjectSerializer;
 
 class Transaction
@@ -12,11 +12,15 @@ class Transaction
     protected ?string $currency;
     protected ?string $language = null;
     protected ?array $totalTaxes = null;
-    protected ?array $allowedPaymentMethodBrands = null;
-    protected ?array $allowedPaymentMethodConfigurations = null;
 
-    protected ?AddressCreate $shippingAddress = null;
-    protected ?AddressCreate $billingAddress = null;
+    public function __construct(protected TransactionCreate $transactionCreate)
+    {
+    }
+
+    public function getTransactionCreateObject(): TransactionCreate
+    {
+        return $this->transactionCreate;
+    }
 
     public function getId(): mixed
     {
@@ -68,62 +72,21 @@ class Transaction
         $this->totalTaxes = $totalTaxes;
     }
 
-    public function getAllowedPaymentMethodBrands(): ?array
-    {
-        return $this->allowedPaymentMethodBrands;
-    }
-
-    public function setAllowedPaymentMethodBrands(?array $allowedPaymentMethodBrands): void
-    {
-        $this->allowedPaymentMethodBrands = $allowedPaymentMethodBrands;
-    }
-
-    public function getAllowedPaymentMethodConfigurations(): ?array
-    {
-        return $this->allowedPaymentMethodConfigurations;
-    }
-
-    public function setAllowedPaymentMethodConfigurations(?array $allowedPaymentMethodConfigurations): void
-    {
-        $this->allowedPaymentMethodConfigurations = $allowedPaymentMethodConfigurations;
-    }
-
-    public function getShippingAddress(): ?AddressCreate
-    {
-        return $this->shippingAddress;
-    }
-
-    public function setShippingAddress(?AddressCreate $shippingAddress): void
-    {
-        $this->shippingAddress = $shippingAddress;
-    }
-
-    public function getBillingAddress(): ?AddressCreate
-    {
-        return $this->billingAddress;
-    }
-
-    public function setBillingAddress(?AddressCreate $billingAddress): void
-    {
-        $this->billingAddress = $billingAddress;
-    }
-
     public function toArray(): array
     {
-        $data = [
-            'id'                                 => $this->getId(),
-            'amount'                             => $this->getAmount(),
-            'currency'                           => $this->getCurrency(),
-            'language'                           => $this->getLanguage(),
-            'totalTaxes'                         => $this->getTotalTaxes(),
-            'allowedPaymentMethodBrands'         => $this->getAllowedPaymentMethodBrands(),
-            'allowedPaymentMethodConfigurations' => $this->getAllowedPaymentMethodConfigurations(),
-            'shippingAddress'                    => $this->shippingAddress === null ? [] : (array) ObjectSerializer::sanitizeForSerialization($this->shippingAddress),
-            'billingAddress'                     => $this->billingAddress === null ? [] : (array) ObjectSerializer::sanitizeForSerialization($this->billingAddress)
-        ];
+        $transactionCreateJson = ObjectSerializer::json_encode(
+            ObjectSerializer::sanitizeForSerialization(
+                $this->getTransactionCreateObject()
+            )
+        );
 
-        return array_filter($data, static function ($row) {
-            return $row !== null;
-        });
+        return [
+            'id'                => $this->getId(),
+            'amount'            => $this->getAmount(),
+            'currency'          => $this->getCurrency(),
+            'language'          => $this->getLanguage(),
+            'totalTaxes'        => $this->getTotalTaxes(),
+            'transactionCreate' => ObjectSerializer::json_decode($transactionCreateJson)
+        ];
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,13 @@
         {
             "name": "DACHCOM.DIGITAL Robert Kaczmarczyk",
             "email": "rkaczmarczyk@dachcom.ch",
-            "homepage": "http://www.dachcom.com",
+            "homepage": "https://www.dachcom.com",
             "role": "Developer"
         },
         {
             "name": "DACHCOM.DIGITAL Stefan Hagspiel",
             "email": "shagspiel@dachcom.ch",
-            "homepage": "http://www.dachcom.com",
+            "homepage": "https://www.dachcom.com",
             "role": "Developer"
         }
     ],
@@ -28,7 +28,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "1.1.x-dev"
+            "dev-main": "3.0.x-dev"
         }
     },
     "autoload": {


### PR DESCRIPTION
`TransactionCreate` Object added: The object `DachcomDigital\Payum\PostFinance\Flex\Transaction\Transaction` 
now provides a `getTransactionCreateObject` method, which gives you full control over the transaction data. 
Therefor we've removed several methods within the `Transaction` object itself.
Use to the `TransactionCreate` object directly, to add additional data.
  - Removed methods:
    - `(get|set)AllowedPaymentMethodBrands`
    - `(get|set)AllowedPaymentMethodConfigurations`
    - `(get|set)ShippingAddress`
    - `(get|set)BillingAddress`
  - Signature of `transaction_extender` within the payment `details` has changed:
    - `transactionCreate` added
    - `allowedPaymentMethodBrands`, `allowedPaymentMethodConfigurations`, `shippingAddress`, `billingAddress` removed